### PR TITLE
Depend on bytestring >= 0.11.1.0 for doctests

### DIFF
--- a/http-types.cabal
+++ b/http-types.cabal
@@ -72,4 +72,6 @@ Test-Suite doctests
   type:                exitcode-stdio-1.0
   ghc-options:         -threaded -Wall
   default-language:    Haskell2010
-  build-depends:       base, doctest >= 0.9.3
+  build-depends:       base,
+                       bytestring >= 0.11.1.0,
+                       doctest >= 0.9.3


### PR DESCRIPTION
The newly added doctests uses Builder's Show instance which is only available since https://github.com/haskell/bytestring/commit/7851d7ac0472ac78b3202659a74f16af78dbcfb7

The tests will fail with older bytestring:

```
Test suite doctests: RUNNING...
./Network/HTTP/Types/URI.hs:385: failure in expression `encodePathSegments ["foo", "bar1", "~baz"]'
expected: "/foo/bar1/~baz"
 but got: 
          ^
          <interactive>:41:1: error:
              • No instance for (Show B.Builder) arising from a use of ‘print’
              • In a stmt of an interactive GHCi command: print it

Examples: 28  Tried: 26  Errors: 0  Failures: 1
Test suite doctests: FAIL
```