### PR TITLE
Revert "Depend on bytestring >= 0.11.1.0 for doctests"

### DIFF
--- a/http-types.cabal
+++ b/http-types.cabal
@@ -72,6 +72,4 @@ Test-Suite doctests
   type:                exitcode-stdio-1.0
   ghc-options:         -threaded -Wall
   default-language:    Haskell2010
-  build-depends:       base,
-                       bytestring >= 0.11.1.0,
-                       doctest >= 0.9.3
+  build-depends:       base, doctest >= 0.9.3


### PR DESCRIPTION
Reverts Vlix/http-types#20

Erroneously merged in. Fix was already present.