### PR TITLE
Fix broken Haddock links

### DIFF
--- a/Network/HTTP/Types/Method.hs
+++ b/Network/HTTP/Types/Method.hs
@@ -6,7 +6,7 @@
 -- The HTTP standard defines a set of standard methods, when to use them,
 -- and how to handle them. The standard set has been provided as a separate
 -- data type 'StdMethod', but since you can also use custom methods, the
--- basic type 'Method' is just a synonym for 'ByteString'.
+-- basic type 'Method' is just a synonym for 'B.ByteString'.
 module Network.HTTP.Types.Method (
     -- * HTTP methods
     Method,
@@ -50,7 +50,7 @@ import GHC.Generics (Generic)
 --     arbitrary = encodeUtf8 . pack <$> arbitrary
 -- :}
 
--- | HTTP method (flat 'ByteString' type).
+-- | HTTP method (flat 'B.ByteString' type).
 type Method = B.ByteString
 
 -- | HTTP GET Method
@@ -133,13 +133,13 @@ methodArray = listArray (minBound, maxBound) $ map (B8.pack . show) [minBound ::
 methodList :: [(Method, StdMethod)]
 methodList = map (\(a, b) -> (b, a)) (assocs methodArray)
 
--- | Convert a method 'ByteString' to a 'StdMethod' if possible.
+-- | Convert a method 'B.ByteString' to a 'StdMethod' if possible.
 --
 -- @since 0.2.0
 parseMethod :: Method -> Either B.ByteString StdMethod
 parseMethod bs = maybe (Left bs) Right $ lookup bs methodList
 
--- | Convert an algebraic method to a 'ByteString'.
+-- | Convert an algebraic method to a 'B.ByteString'.
 --
 -- prop> renderMethod (parseMethod bs) == bs
 --
@@ -147,7 +147,7 @@ parseMethod bs = maybe (Left bs) Right $ lookup bs methodList
 renderMethod :: Either B.ByteString StdMethod -> Method
 renderMethod = id ||| renderStdMethod
 
--- | Convert a 'StdMethod' to a 'ByteString'.
+-- | Convert a 'StdMethod' to a 'B.ByteString'.
 --
 -- @since 0.2.0
 renderStdMethod :: StdMethod -> Method

--- a/Network/HTTP/Types/URI.hs
+++ b/Network/HTTP/Types/URI.hs
@@ -169,7 +169,7 @@ type SimpleQuery = [SimpleQueryItem]
 simpleQueryToQuery :: SimpleQuery -> Query
 simpleQueryToQuery = map (second Just)
 
--- | Renders the given 'Query' into a 'Builder'.
+-- | Renders the given 'Query' into a 'B.Builder'.
 --
 -- If you want a question mark (@?@) added to the front of the result, use 'True'.
 --
@@ -202,7 +202,7 @@ renderQueryBuilder qmark' (p : ps) =
 renderQuery :: Bool -> Query -> B.ByteString
 renderQuery qm = BL.toStrict . B.toLazyByteString . renderQueryBuilder qm
 
--- | Render the given 'SimpleQuery' into a 'ByteString'.
+-- | Render the given 'SimpleQuery' into a 'B.ByteString'.
 --
 -- If you want a question mark (@?@) added to the front of the result, use 'True'.
 --
@@ -262,7 +262,7 @@ breakDiscard seps s =
     let (x, y) = B.break (`B.elem` seps) s
      in (x, B.drop 1 y)
 
--- | Parse 'SimpleQuery' from a 'ByteString'.
+-- | Parse 'SimpleQuery' from a 'B.ByteString'.
 --
 -- This uses 'parseQuery' under the hood, and will transform
 -- any 'Nothing' values into an empty 'B.ByteString'.
@@ -523,7 +523,7 @@ type PartialEscapeQueryItem = (B.ByteString, [EscapeItem])
 -- @since 0.12.1
 type PartialEscapeQuery = [PartialEscapeQueryItem]
 
--- | Convert 'PartialEscapeQuery' to 'ByteString'.
+-- | Convert 'PartialEscapeQuery' to 'B.ByteString'.
 --
 -- If you want a question mark (@?@) added to the front of the result, use 'True'.
 --


### PR DESCRIPTION
Fix all broken Haddock links. Now Haddock doesn't emit any warnings about out-of-scope identifiers.