### PR TITLE
remove 'array' dependency in 'Method.hs'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `http-types`
 
+## 0.12.6 [unreleased]
+
+* Remove `array` dependency
+
 ## 0.12.5 [2026-05-31]
 
 * Add status `451 Unavailable For Legal Reasons`

--- a/Network/HTTP/Types/Method.hs
+++ b/Network/HTTP/Types/Method.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Types and constants for HTTP methods.
 --
@@ -32,11 +33,9 @@ module Network.HTTP.Types.Method (
 )
 where
 
-import Control.Arrow ((|||))
-import Data.Array (Array, Ix, assocs, listArray, (!))
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Char8 as B8
 import Data.Data (Data)
+import Data.Ix (Ix)
 import GHC.Generics (Generic)
 
 -- $setup
@@ -123,13 +122,8 @@ data StdMethod
 -- The reason is that methodList is used with lookup.
 -- lookup is probably faster for these few cases than setting up an elaborate data structure.
 
--- FIXME: listArray (minBound, maxBound) $ fmap fst methodList
-methodArray :: Array StdMethod Method
-methodArray = listArray (minBound, maxBound) $ map (B8.pack . show) [minBound :: StdMethod .. maxBound]
-
--- FIXME: map (\m -> (B8.pack $ show m, m)) [minBound .. maxBound]
 methodList :: [(Method, StdMethod)]
-methodList = map (\(a, b) -> (b, a)) (assocs methodArray)
+methodList = map (\m -> (renderStdMethod m, m)) [minBound .. maxBound]
 
 -- | Convert a method 'B.ByteString' to a 'StdMethod' if possible.
 --
@@ -143,10 +137,20 @@ parseMethod bs = maybe (Left bs) Right $ lookup bs methodList
 --
 -- @since 0.3.0
 renderMethod :: Either B.ByteString StdMethod -> Method
-renderMethod = id ||| renderStdMethod
+renderMethod = either id renderStdMethod
 
 -- | Convert a 'StdMethod' to a 'B.ByteString'.
 --
 -- @since 0.2.0
 renderStdMethod :: StdMethod -> Method
-renderStdMethod m = methodArray ! m
+renderStdMethod method =
+    case method of
+        GET -> "GET"
+        POST -> "POST"
+        HEAD -> "HEAD"
+        PUT -> "PUT"
+        DELETE -> "DELETE"
+        TRACE -> "TRACE"
+        CONNECT -> "CONNECT"
+        OPTIONS -> "OPTIONS"
+        PATCH -> "PATCH"

--- a/http-types.cabal
+++ b/http-types.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       2.2
 Name:                http-types
-Version:             0.12.5
+Version:             0.12.6
 Synopsis:            Generic HTTP types for Haskell (for both client and server code).
 Description:         Types and functions to describe and handle HTTP concepts.
                      Including "methods", "headers", "query strings", "paths" and "HTTP versions".
@@ -41,7 +41,6 @@ Library
   GHC-Options:         -Wall
   Build-depends:       base >= 4.8 && < 5,
                        bytestring >= 0.10.6.0 && < 1,
-                       array >= 0.5.1.0 && < 0.6,
                        case-insensitive >= 1.2.0.2 && < 1.3,
                        text >= 1.2.0.2 && < 3
   Default-language:    Haskell2010


### PR DESCRIPTION
Found the `array` depedency to be unnecessary, and potentially `renderStdMethod` is now even quicker/more efficient.

Fun fact:
Also saw with `-ddump-simpl` that the `Method` constants get compiled to literal `ByteString`s, and that the `ByteString`s in the case of `renderStdMethod` are replaced by the constants that were defined in terms of `renderStdMethod` 🤔 